### PR TITLE
add touchstart event

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -104,6 +104,15 @@ var autoComplete = (function(){
                 }
             }, that.sc);
 
+            live('autocomplete-suggestion', 'touchstart', function(e){
+                if (hasClass(this, 'autocomplete-suggestion')) { // else outside click
+                    var v = this.getAttribute('data-val');
+                    that.value = v;
+                    o.onSelect(e, v, this);
+                    that.sc.style.display = 'none';
+                }
+            }, that.sc);
+
             that.blurHandler = function(){
                 try { var over_sb = document.querySelector('.autocomplete-suggestions:hover'); } catch(e){ var over_sb = 0; }
                 if (!over_sb) {


### PR DESCRIPTION
This solves problem on mobile devices, where the event mousedown may not be triggered by browser.
In my case a Samsung Galaxy Tab, that was not able to select the item shown.
