### PR TITLE
Chrome no longer respects autocomplete="off"

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -57,7 +57,7 @@ var autoComplete = (function(){
             that.sc.className = 'autocomplete-suggestions '+o.menuClass;
 
             that.autocompleteAttr = that.getAttribute('autocomplete');
-            that.setAttribute('autocomplete', 'off');
+            that.setAttribute('autocomplete', 'false');
             that.cache = {};
             that.last_val = '';
 


### PR DESCRIPTION
Come to find out, autocomplete must be set to "false" instead of "off" now for Chrome. Additionally, if the form has autocomplete="on" then that appears to override everything.
