### PR TITLE
Added the ability to customize the result container instead of appending directly to the body.

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -57,16 +57,24 @@ var autoComplete = (function(){
             that.sc = document.createElement('div');
             that.sc.className = 'autocomplete-suggestions '+o.menuClass;
 
+            // If adding into a results container, remove the position absolute css styles
+            if (o.container !== "body") {
+                that.sc.className = that.sc.className + ' autocomplete-suggestions--in-container';
+            }
+
             that.autocompleteAttr = that.getAttribute('autocomplete');
             that.setAttribute('autocomplete', 'off');
             that.cache = {};
             that.last_val = '';
 
             that.updateSC = function(resize, next){
-                var rect = that.getBoundingClientRect();
-                that.sc.style.left = Math.round(rect.left + (window.pageXOffset || document.documentElement.scrollLeft) + o.offsetLeft) + 'px';
-                that.sc.style.top = Math.round(rect.bottom + (window.pageYOffset || document.documentElement.scrollTop) + o.offsetTop) + 'px';
-                that.sc.style.width = Math.round(rect.right - rect.left) + 'px'; // outerWidth
+                if (o.container === 'body') {
+                    // If the container is not the body, do not absolutely position in the window.
+                    var rect = that.getBoundingClientRect();
+                    that.sc.style.left = Math.round(rect.left + (window.pageXOffset || document.documentElement.scrollLeft) + o.offsetLeft) + 'px';
+                    that.sc.style.top = Math.round(rect.bottom + (window.pageYOffset || document.documentElement.scrollTop) + o.offsetTop) + 'px';
+                    that.sc.style.width = Math.round(rect.right - rect.left) + 'px'; // outerWidth
+                }
                 if (!resize) {
                     that.sc.style.display = 'block';
                     if (!that.sc.maxHeight) { that.sc.maxHeight = parseInt((window.getComputedStyle ? getComputedStyle(that.sc, null) : that.sc.currentStyle).maxHeight); }

--- a/auto-complete.js
+++ b/auto-complete.js
@@ -37,6 +37,7 @@ var autoComplete = (function(){
             offsetTop: 1,
             cache: 1,
             menuClass: '',
+            container: 'body',
             renderItem: function (item, search){
                 // escape special characters
                 search = search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -82,7 +83,7 @@ var autoComplete = (function(){
                 }
             }
             addEvent(window, 'resize', that.updateSC);
-            document.body.appendChild(that.sc);
+            document.querySelector(o.container).appendChild(that.sc);
 
             live('autocomplete-suggestion', 'mouseleave', function(e){
                 var sel = that.sc.querySelector('.autocomplete-suggestion.selected');

--- a/demo.html
+++ b/demo.html
@@ -239,6 +239,40 @@ new autoComplete({
             However, when choosing an item, the <span class="inline-code">onSelect()</span> callback returns all required information.
         </p>
 
+
+        <h4>Customizing the Display Container</h4>
+        <p>Sometimes you don't want the container to be just placed at the end of the body tag, and it would make more sense for your use case to have it display in a different location.
+        To do something like that, you would just have to scaffold out an empty block container (div, section, etc) for results, and then pass a class or ID attached to that container into
+        the options when you initalize autocomplete:</p>
+
+
+        <form onsubmit="return false;" class="pure-form" style="margin:30px 0 40px">
+            <input id="container-demo" autofocus type="text" name="q" placeholder="See the results ..." style="width:100%;max-width:600px;outline:0">
+        </form>
+
+        <div class="results-container"></div>
+        
+        <pre class="prettyprint"><code>var demo3 = new autoComplete({
+            selector: '#container-demo',
+            minChars: 1,
+            container: '.results-container',
+            source: function(term, suggest){
+                term = term.toLowerCase();
+                var choices = ['ActionScript', 'AppleScript', 'Asp', 'Assembly', 'BASIC', 'Batch', 'C', 'C++', 'CSS', 'Clojure', 'COBOL', 'ColdFusion', 'Erlang', 'Fortran', 'Groovy', 'Haskell', 'HTML', 'Java', 'JavaScript', 'Lisp', 'Perl', 'PHP', 'PowerShell', 'Python', 'Ruby', 'Scala', 'Scheme', 'SQL', 'TeX', 'XML'];
+                var suggestions = [];
+                for (i=0;i&lt;choices.length;i++)
+                    if (~choices[i].toLowerCase().indexOf(term)) suggestions.push(choices[i]);
+                suggest(suggestions);
+            }
+        });</code></pre>
+        
+        <pre class="prettyprint"><code>&lt;form onsubmit="return false;" class="pure-form" style="margin:30px 0 40px"&gt;
+            &lt;input id="container-demo" autofocus type="text" name="q" placeholder="See the results ..." style="width:100%;max-width:600px;outline:0"&gt;
+        &lt;/form&gt;
+
+        &lt;div class="results-container"&gt;&lt;/div&gt;</code></pre>
+
+
         <div style="margin:60px 0 40px;overflow:hidden;border-top:1px solid #eee;padding-top:40px">
             <span id="github_social"></span>
             <div style="float:left;margin-right:35px">
@@ -298,6 +332,20 @@ new autoComplete({
             onSelect: function(e, term, item){
                 console.log('Item "'+item.getAttribute('data-langname')+' ('+item.getAttribute('data-lang')+')" selected by '+(e.type == 'keydown' ? 'pressing enter' : 'mouse click')+'.');
                 document.getElementById('advanced-demo').value = item.getAttribute('data-langname')+' ('+item.getAttribute('data-lang')+')';
+            }
+        });
+
+        var demo3 = new autoComplete({
+            selector: '#container-demo',
+            minChars: 1,
+            container: '.results-container',
+            source: function(term, suggest){
+                term = term.toLowerCase();
+                var choices = ['ActionScript', 'AppleScript', 'Asp', 'Assembly', 'BASIC', 'Batch', 'C', 'C++', 'CSS', 'Clojure', 'COBOL', 'ColdFusion', 'Erlang', 'Fortran', 'Groovy', 'Haskell', 'HTML', 'Java', 'JavaScript', 'Lisp', 'Perl', 'PHP', 'PowerShell', 'Python', 'Ruby', 'Scala', 'Scheme', 'SQL', 'TeX', 'XML'];
+                var suggestions = [];
+                for (i=0;i<choices.length;i++)
+                    if (~choices[i].toLowerCase().indexOf(term)) suggestions.push(choices[i]);
+                suggest(suggestions);
             }
         });
 


### PR DESCRIPTION
This specifically works for me in a situation where I have a fixed header, but I realized that sometimes people scroll while the results are still visible.  This means that the results end up staying positioned absolutely in the page, while the search bar moves around because it's fixed.  So, I added in the ability to add a "container" option where you pass a selector in and the results are then appended there instead of the body.  Default functionality still applies if you don't add any selections.  I've also added another class if you do define the result set, so that you can add CSS to remove the position absolute if you need to.
