### PR TITLE
Fix race-condition issue with ajax sources

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -114,8 +114,10 @@ var autoComplete = (function(){
             };
             addEvent(that, 'blur', that.blurHandler);
 
-            var suggest = function(data){
-                var val = that.value;
+            var suggest = function(data, val){
+                if (!val) {
+                    var val = that.value;
+                }
                 that.cache[val] = data;
                 if (data.length && val.length >= o.minChars) {
                     var s = '';
@@ -152,6 +154,9 @@ var autoComplete = (function(){
                 else if (key == 27) { that.value = that.last_val; that.sc.style.display = 'none'; }
                 // enter
                 else if (key == 13 || key == 9) {
+                    if (that.sc.style.display !== 'none') {
+                        e.preventDefault();
+                    }
                     var sel = that.sc.querySelector('.autocomplete-suggestion.selected');
                     if (sel && that.sc.style.display != 'none') { o.onSelect(e, sel.getAttribute('data-val'), sel); setTimeout(function(){ that.sc.style.display = 'none'; }, 20); }
                 }
@@ -167,7 +172,7 @@ var autoComplete = (function(){
                             that.last_val = val;
                             clearTimeout(that.timer);
                             if (o.cache) {
-                                if (val in that.cache) { suggest(that.cache[val]); return; }
+                                if (val in that.cache) {suggest(that.cache[val]); return;}
                                 // no requests if previous suggestions were empty
                                 for (var i=1; i<val.length-o.minChars; i++) {
                                     var part = val.slice(0, val.length-i);


### PR DESCRIPTION
currently, if you use a ajax call in your source callback you can run into issues
where results are stored under a wrong search term. This change adds an additional
argument to the source callback to specify the search term in order to gurantee
the storage of the results under the correct search term.
